### PR TITLE
Fix for rejected transactions.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1059,7 +1059,7 @@ int CMerkleTx::GetBlocksToMaturity() const
 {
     if (!(IsCoinBase() || IsCoinStake()))
         return 0;
-    return max(0, nCoinbaseMaturity - GetDepthInMainChain());
+    return max(0, (nCoinbaseMaturity+1) - GetDepthInMainChain());
 }
 
 


### PR DESCRIPTION
When sending coins, the wallet throws an error:
error: {"code":-4,"message":"Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here."}

While debug.log shows:
2016-03-27 19:22:24 ERROR: ConnectInputs() : tried to spend coinbase at depth 59
2016-03-27 19:22:24 ERROR: AcceptToMemoryPool : ConnectInputs failed <hash>
2016-03-27 19:22:24 CommitTransaction() : Error: Transaction not valid
